### PR TITLE
crypto/tls: make checkForResumption side-effect free

### DIFF
--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -357,26 +357,26 @@ func (hs *serverHandshakeState) checkForResumption() bool {
 	if plaintext == nil {
 		return false
 	}
-	hs.sessionState = &sessionState{usedOldKey: usedOldKey}
-	ok := hs.sessionState.unmarshal(plaintext)
+	clientSessionState := &sessionState{usedOldKey: usedOldKey}
+	ok := clientSessionState.unmarshal(plaintext)
 	if !ok {
 		return false
 	}
 
-	createdAt := time.Unix(int64(hs.sessionState.createdAt), 0)
+	createdAt := time.Unix(int64(clientSessionState.createdAt), 0)
 	if c.config.time().Sub(createdAt) > maxSessionTicketLifetime {
 		return false
 	}
 
 	// Never resume a session for a different TLS version.
-	if c.vers != hs.sessionState.vers {
+	if c.vers != clientSessionState.vers {
 		return false
 	}
 
 	cipherSuiteOk := false
 	// Check that the client is still offering the ciphersuite in the session.
 	for _, id := range hs.clientHello.cipherSuites {
-		if id == hs.sessionState.cipherSuite {
+		if id == clientSessionState.cipherSuite {
 			cipherSuiteOk = true
 			break
 		}
@@ -385,14 +385,7 @@ func (hs *serverHandshakeState) checkForResumption() bool {
 		return false
 	}
 
-	// Check that we also support the ciphersuite from the session.
-	hs.suite = selectCipherSuite([]uint16{hs.sessionState.cipherSuite},
-		c.config.cipherSuites(), hs.cipherSuiteOk)
-	if hs.suite == nil {
-		return false
-	}
-
-	sessionHasClientCerts := len(hs.sessionState.certificates) != 0
+	sessionHasClientCerts := len(clientSessionState.certificates) != 0
 	needClientCerts := requiresClientCert(c.config.ClientAuth)
 	if needClientCerts && !sessionHasClientCerts {
 		return false
@@ -400,6 +393,15 @@ func (hs *serverHandshakeState) checkForResumption() bool {
 	if sessionHasClientCerts && c.config.ClientAuth == NoClientCert {
 		return false
 	}
+
+	// Check that we also support the ciphersuite from the session.
+	hs.suite = selectCipherSuite([]uint16{clientSessionState.cipherSuite},
+		c.config.cipherSuites(), hs.cipherSuiteOk)
+	if hs.suite == nil {
+		return false
+	}
+
+	hs.sessionState = clientSessionState
 
 	return true
 }


### PR DESCRIPTION
Fixes #39406
When use checkForResumption() function it could be side-effect sometime.
1. hs.sessionState will be changed and retained although the function return false.
2. hs.suite will be changed and retained when the statements below return false.
So  we should use a local variable, cilentSessionState, to replace hs.sessionState in the function. And move the set-suite statements down to avoid being changed too early.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
